### PR TITLE
fix: compare date strings instead of objects in checkChange

### DIFF
--- a/ui/src/component/QCalendar.js
+++ b/ui/src/component/QCalendar.js
@@ -151,9 +151,9 @@ export default {
     checkChange (val, oldval) {
       const { start, end } = this.renderProps
       this.keyValue = 0
-      if (start !== this.lastStart || end !== this.lastEnd) {
-        this.lastStart = start
-        this.lastEnd = end
+      if (!this.lastStart || !this.lastEnd || start.date !== this.lastStart || end.date !== this.lastEnd) {
+        this.lastStart = start.date
+        this.lastEnd = end.date
         this.$emit('change', { start, end })
       }
       this.keyValue = getDayIdentifier(start)


### PR DESCRIPTION
Comparing the start/end and lastStart/lastEnd objects always returns true which means that a `change` event is emitted on every change of `renderProps`, even if the dates have not changed.
This combined with data that depends on the date interval as returned by QCalendar will result in an infinite loop.

Checking against the date string fixes this problem.