### PR TITLE
First implementation of sub-resources

### DIFF
--- a/ui/src/components/QCalendarScheduler.js
+++ b/ui/src/components/QCalendarScheduler.js
@@ -401,7 +401,46 @@ export default {
     },
 
     __renderDayResources (h, day, idx) {
-      return this.resources.map(resource => this.__renderDayResource(h, resource, day, idx))
+      const dayResources = []
+      this.resources.forEach((resource) => {
+        dayResources.push(this.__renderDayResource(h, resource, day, idx))
+        if (resource.expanded) {
+          dayResources.push(this.__renderDayBodySubResources(h, resource[this.subResourceKey], day))
+        }
+      })
+      return dayResources
+    },
+
+    __renderDayBodySubResources (h, subResources, day) {
+      if (subResources === void 0) {
+        console.warn('subResources not defined')
+        return
+      }
+      return h('div', {
+        staticClass: 'q-calendar-scheduler__day-sub-resources-body',
+        style: {}
+      }, [...this.__renderDaySubResources(h, subResources, day)])
+    },
+
+    __renderDaySubResources (h, subResources, day) {
+      return subResources.map((subResource, idx) => this.__renderDaySubResource(h, subResource, day, idx))
+    },
+
+    __renderDaySubResource (h, subResource, day, idx) {
+      const subResourceSlot = this.$scopedSlots['scheduler-day-sub-resource']
+      const subResourceScope = {
+        subResource,
+        timestamp: day,
+        index: idx
+      }
+      return h('div', {
+        staticClass: 'q-calendar-scheduler__day-sub-resource',
+        style: {
+          height: convertToUnit(subResource.subResourceHeight ? subResource.subResourceHeight : this.subResourceHeight)
+        }
+      }, [
+        subResourceSlot ? subResourceSlot(subResourceScope) : this.$scopedSlots.default
+      ])
     },
 
     __renderDayResource (h, resource, day, idx) {
@@ -444,6 +483,39 @@ export default {
       return h('div', data, children)
     },
 
+    __renderBodySubResources (h, subResources) {
+      if (subResources === void 0) {
+        console.warn('subResources not defined')
+        return
+      }
+      return h('div', {
+        staticClass: 'q-calendar-scheduler__sub-resources-body',
+        style: {}
+      }, [
+        ...this.__renderSubResources(h, subResources)
+      ])
+    },
+
+    __renderSubResources (h, subResources) {
+      return subResources.map((subResource, idx) => this.__renderSubResource(h, subResource, idx))
+    },
+
+    __renderSubResource (h, subResource, idx) {
+      const subResourceSlot = this.$scopedSlots['scheduler-sub-resource']
+      const subResourceScope = {
+        subResource,
+        index: idx
+      }
+      return h('div', {
+        staticClass: 'q-calendar-scheduler__sub-resource',
+        style: {
+          height: convertToUnit(subResource.subResourceHeight ? subResource.subResourceHeight : this.subResourceHeight)
+        }
+      }, [
+        subResourceSlot ? subResourceSlot(subResourceScope) : this.$scopedSlots.default
+      ])
+    },
+
     __renderBodyResources (h) {
       const width = convertToUnit(this.resourceWidth)
       let colors = new Map(), color, backgroundColor
@@ -466,7 +538,14 @@ export default {
     },
 
     __renderResourceLabels (h) {
-      return this.resources.map((resource, idx) => this.__renderResourceLabel(h, resource, idx))
+      const resourceLabels = []
+      this.resources.forEach((resource, idx) => {
+        resourceLabels.push(this.__renderResourceLabel(h, resource, idx))
+        if (resource.expanded) {
+          resourceLabels.push(this.__renderBodySubResources(h, resource[this.subResourceKey]))
+        }
+      })
+      return resourceLabels
     },
 
     __renderResourceLabel (h, resource, idx) {
@@ -494,7 +573,9 @@ export default {
         key: label + (idx !== void 0 ? '-' + idx : ''),
         staticClass: 'q-calendar-scheduler__resource',
         style: {
-          height
+          height,
+          display: 'flex',
+          flexDirection: 'column'
         },
         on: this.getDefaultMouseEventHandlers(':resource', event => {
           return { scope, event }

--- a/ui/src/css/calendar-scheduler.sass
+++ b/ui/src/css/calendar-scheduler.sass
@@ -47,6 +47,7 @@
 
   .q-calendar-scheduler__resources-body
     border-right: $calendar-border-color $calendar-border-width solid
+    border-bottom: $calendar-border-color $calendar-border-width solid
 
     .q-calendar-scheduler__resource-text
       color: $calendar-text-color
@@ -58,6 +59,11 @@
     &.q-current-day
       // border $calendar-border-color $calendar-border-width solid
 
+  .q-calendar-scheduler__day-sub-resource
+    border-top: $calendar-border-color $calendar-border-width solid
+
+  .q-calendar-scheduler__sub-resource
+    border-top: $calendar-border-color $calendar-border-width solid
   .q-calendar-scheduler__resource
     border-top: $calendar-border-color $calendar-border-width solid
     color: $calendar-text-color
@@ -247,6 +253,7 @@
 
     .q-calendar-scheduler__resources-body
       border-right: $calendar-border-color-dark $calendar-border-width solid
+      border-bottom: $calendar-border-color-dark $calendar-border-width solid
 
       .q-calendar-scheduler__resource-text
         color: $calendar-text-color-dark
@@ -257,6 +264,11 @@
 
       &.q-current-day
         // border $calendar-border-color-dark $calendar-border-width solid
+    .q-calendar-scheduler__day-sub-resource
+      border-top: $calendar-border-color-dark $calendar-border-width solid
+
+    .q-calendar-scheduler__sub-resource
+      border-top: $calendar-border-color-dark $calendar-border-width solid
 
     .q-calendar-scheduler__resource
       border-top: $calendar-border-color-dark $calendar-border-width solid

--- a/ui/src/mixins/calendar-scheduler.js
+++ b/ui/src/mixins/calendar-scheduler.js
@@ -32,7 +32,11 @@ export default {
 
     bodyHeight () {
       if (this.resources && this.resources.length > 0) {
-        return this.resources.length * this.parsedResourceHeight
+        let bodyHeight = 0
+        for (let i = 0; i < this.resources.length; i++) {
+          bodyHeight += this.getResourceHeight(this.resources[i])
+        }
+        return bodyHeight
       }
       return 0
     },
@@ -71,6 +75,28 @@ export default {
         scope.resource = resource
       }
       return scope
+    },
+
+    getResourceHeight (resource) {
+      if (!resource.expanded) {
+        return this.resourceHeight
+      }
+
+      const subResource = resource[this.subResourceKey]
+      if (subResource === void 0) {
+        console.warn('resource object requires a ', this.subResourceKey + ' label')
+        return this.resourceHeight
+      }
+
+      let newResourceHeight = this.resourceHeight
+      for (let i = 0; i < subResource.length; i++) {
+        if (subResource[i].subResourceHeight === void 0) {
+          newResourceHeight += this.subResourceHeight
+        } else {
+          newResourceHeight += subResource[i].subResourceHeight
+        }
+      }
+      return newResourceHeight
     }
   }
 }

--- a/ui/src/utils/props.js
+++ b/ui/src/utils/props.js
@@ -180,6 +180,15 @@ export default {
       type: Function,
       default: null
     },
+    subResourceKey: {
+      type: String,
+      default: 'subResourceLabel'
+    },
+    subResourceHeight: {
+      type: [Number, String],
+      default: 25,
+      validator: validateNumber
+    },
     columnHeaderBefore: Boolean,
     columnHeaderAfter: Boolean,
     columnCount: {


### PR DESCRIPTION
This is the first implementation of the sub-resources feature.
There are 2 new props:

- subResourcKey
 This is to define the key of the subResource which must exist on the resource.
- subResourceHeight
This defines the height of each subResource

There is one new key on the resource which is needed
- expanded 
If this is true the subResource gets expanded and collapses if it is false

Also there is an optional key on the subResource
- subResourceHeight
This is to define a custom height for a subResource if one is needed otherwise it defaults to prop subResourceHeight

We are not sure if this fits the standards of the project but we tried our best to maintain the same conventions.
There may be a few things which are not perfectly finished like drag and drop functionality and theme but
we wanted to check back first if our approach is on the right track.
