### PR TITLE
chore(docs): fix spelling in "disabled-after" example

### DIFF
--- a/ui/src/components/QCalendar.json
+++ b/ui/src/components/QCalendar.json
@@ -144,7 +144,7 @@
         "All"
       ],
       "examples": [
-        "disabled-before=\"2019-04-01\""
+        "disabled-after=\"2019-04-01\""
       ]
     },
     "locale": {


### PR DESCRIPTION
Noticed a small typo/copy-paste-issue while referencing the qcalendar API docs.
Thanks for all your effort!

Cheers :)