### PR TITLE
fs-extra is required by build script

### DIFF
--- a/ui/build/script.javascript.js
+++ b/ui/build/script.javascript.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const fs = require('fs')
-const fse = require('fs-extra')
+const fs = require('fs-extra')
 const rollup = require('rollup')
 const uglify = require('uglify-es')
 const buble = require('@rollup/plugin-buble')
@@ -170,7 +169,7 @@ function addAssets (builds, type, injectName) {
     plugins = [buble(bubleConfig)],
     outputDir = pathResolve(`../dist/${type}`)
 
-  fse.mkdirp(outputDir)
+  fs.mkdirp(outputDir)
 
   files
     .filter(file => file.endsWith('.js'))

--- a/ui/package.json
+++ b/ui/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-quasar": "^1.0.0",
     "eslint-plugin-vue": "^7.5.0",
     "eslint-webpack-plugin": "^2.5.0",
+    "fs-extra": "^9.1.0",
     "jest": "^26.6.3",
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",


### PR DESCRIPTION
The build script requires the `fs-extra` module, so this is needed as a dependency in `package.json`.
And if using `fs-extra`, you can replace `fs` with `fs-extra`.