### PR TITLE
Agenda: Full height day seperators

### DIFF
--- a/ui/src/components/QCalendarAgenda.js
+++ b/ui/src/components/QCalendarAgenda.js
@@ -862,7 +862,8 @@ export default defineComponent({
         h('div', {
           style: {
             display: 'flex',
-            flexDirection: 'row'
+            flexDirection: 'row',
+            height: '100%'
           }
         }, [
           ...__renderDays()

--- a/ui/src/css/calendar-agenda.sass
+++ b/ui/src/css/calendar-agenda.sass
@@ -99,6 +99,7 @@
 
   &__pane
     width: 100%
+    height: 100%
     overflow: hidden
     flex: none
     display: flex
@@ -109,6 +110,7 @@
     display: flex
     flex: 1
     flex-direction: column
+    height: 100%
 
   &__intervals-column
     position: relative


### PR DESCRIPTION
If you set a `min-height` on the calendar (here QCalendarAgenda) the day seperator is not rendered on the full height.
So if you have a sample calendar (`min-height: 400px`), currently the days are rendered like this:
![sep-before](https://user-images.githubusercontent.com/1855448/111918883-739fc280-8a87-11eb-90e4-bb444edfc5f0.png)

After applying this changes, it looks like this:
![sep-after](https://user-images.githubusercontent.com/1855448/111918884-77cbe000-8a87-11eb-8438-b3fdf7cfcaf7.png)