### PR TITLE
`Date.UTC(new Date())` should return `NaN`, in IE got `object` without `getFullYear`, `today`, `now` methods.

### DIFF
--- a/ui/src/utils/Timestamp.js
+++ b/ui/src/utils/Timestamp.js
@@ -362,7 +362,7 @@ export function getDayOfYear (timestamp) {
 export function getWorkWeek (timestamp) {
   let date
   if (timestamp.year === 0) {
-    date = Date.UTC(new Date())
+    date = NaN
   }
   else {
     date = makeDate(timestamp)


### PR DESCRIPTION
`Date.UTC(new Date())` should return `NaN`, in IE got `object` without `getFullYear`, `today`, `now` methods.

![изображение](https://user-images.githubusercontent.com/1254277/134437594-3c639992-9c80-46ad-83e4-815d1682d1d4.png)