### PR TITLE
Importing "QCalendarDay" instead of "QCalendar"

### DIFF
--- a/docs/src/pages/all-about-qcalendar/installation-types.md
+++ b/docs/src/pages/all-about-qcalendar/installation-types.md
@@ -103,11 +103,11 @@ There are several variants for each calendar component, including common, es (mo
 <style src="@quasar/quasar-ui-qcalendar/dist/QCalendarDay.min.css"></style>
 
 <script>
-import { QCalendar } from '@quasar/quasar-ui-qcalendar/dist/QCalendarDay.esm.js'
+import { QCalendarDay } from '@quasar/quasar-ui-qcalendar/dist/QCalendarDay.esm.js'
 
 export default {
   components: {
-    QCalendar
+    QCalendarDay
   }
 }
 </script>


### PR DESCRIPTION
Looks like `QCalendarDay.esm.js` exports `QCalendarDay`, not `QCalendar` :)