### PR TITLE
fix(ui): Timstamp.parseTimestamp should set hasTime if midnight is given

### DIFF
--- a/ui/src/utils/Timestamp.js
+++ b/ui/src/utils/Timestamp.js
@@ -259,7 +259,7 @@ export function parsed (input) {
     doy: 0,
     workweek: 0,
     hasDay: !!parts[ 4 ],
-    hasTime: !!(parts[ 6 ] && parts[ 8 ]),
+    hasTime: !isNaN(parts[ 6 ]) && !isNaN(parts[ 8 ]),
     past: false,
     current: false,
     future: false,


### PR DESCRIPTION
Parsing a date time string like `2021-11-28 00:00` should be perfectly fine.
So it is a valid date and a valid time and gets parsed without errors, so the `hasTime` attribute should be set to `true` instead of `false`.

Currently `parts[ 6 ]` evaluates to `0` which is `false` so this will fail.

`isNaN` will return `NaN` event for an undefined value (e.g. time not set) and as `NaN` is evaluated as `false` this will only fail for non valid numbers or if time is not set. 