### PR TITLE
Add missing method printScope in WeekDragAndDrop

### DIFF
--- a/docs/src/examples/WeekDragAndDrop.vue
+++ b/docs/src/examples/WeekDragAndDrop.vue
@@ -245,6 +245,11 @@ export default defineComponent({
     },
     onClickHeadDay (data) {
       console.log('onClickHeadDay', data)
+    },
+    // this method is used only to print the scope to dev tools
+    printScope (scope) {
+      console.log('scope:', scope)
+      return true
     }
   }
 })


### PR DESCRIPTION
The printScope method was missing https://github.com/quasarframework/quasar-ui-qcalendar/issues/379