### PR TITLE
proper component registration

### DIFF
--- a/app-extension/src/boot/register.js
+++ b/app-extension/src/boot/register.js
@@ -1,6 +1,20 @@
 import { boot } from 'quasar/wrappers'
-import VuePlugin from '@quasar/quasar-ui-qcalendar'
+import {
+    QCalendar,
+    QCalendarAgenda,
+    QCalendarDay,
+    QCalendarMonth,
+    QCalendarResource,
+    QCalendarScheduler,
+    QCalendarTask
+} from '@quasar/quasar-ui-qcalendar'
 
 export default boot(({ app }) => {
-  app.use(VuePlugin)
+    app.component(QCalendar.name, QCalendar)
+    app.component(QCalendarAgenda.name, QCalendarAgenda)
+    app.component(QCalendarDay.name, QCalendarDay)
+    app.component(QCalendarMonth.name, QCalendarMonth)
+    app.component(QCalendarResource.name, QCalendarResource)
+    app.component(QCalendarScheduler.name, QCalendarScheduler)
+    app.component(QCalendarTask.name, QCalendarTask)
 })


### PR DESCRIPTION
After adding component with:
quasar ext add @quasar/qcalendar@next

dev-tools show this warning:
[Vue warn]: A plugin must either be a function or an object with an "install" function.
