### PR TITLE
Support Sets as selected dates

### DIFF
--- a/ui/src/components/QCalendarDay.js
+++ b/ui/src/components/QCalendarDay.js
@@ -143,7 +143,8 @@ export default defineComponent({
       ariaDateFormatter,
       // methods
       dayStyleDefault,
-      getRelativeClasses
+      getRelativeClasses,
+      selectedDatesPropArray
     } = useCommon(props, { startDate, endDate, times })
 
     const parsedValue = computed(() => {
@@ -923,7 +924,7 @@ export default defineComponent({
           'q-calendar-day__day-interval': interval.minute === 0,
           'q-calendar-day__day-interval--section': interval.minute !== 0,
           ...intervalClass,
-          ...getIntervalClasses(interval, Array.from(props.selectedDates), props.selectedStartEndDates),
+          ...getIntervalClasses(interval, selectedDatesPropArray.value, props.selectedStartEndDates),
           'q-calendar__hoverable': props.hoverable === true,
           'q-calendar__focusable': isFocusable === true
         },

--- a/ui/src/components/QCalendarDay.js
+++ b/ui/src/components/QCalendarDay.js
@@ -923,7 +923,7 @@ export default defineComponent({
           'q-calendar-day__day-interval': interval.minute === 0,
           'q-calendar-day__day-interval--section': interval.minute !== 0,
           ...intervalClass,
-          ...getIntervalClasses(interval, props.selectedDates, props.selectedStartEndDates),
+          ...getIntervalClasses(interval, Array.from(props.selectedDates), props.selectedStartEndDates),
           'q-calendar__hoverable': props.hoverable === true,
           'q-calendar__focusable': isFocusable === true
         },
@@ -1043,7 +1043,7 @@ export default defineComponent({
       if (startDate.value !== start.date || endDate.value !== end.date || maxDaysRendered.value !== maxDays) {
         startDate.value = start.date
         endDate.value = end.date
-        maxDaysRendered.value = maxDays 
+        maxDaysRendered.value = maxDays
       }
 
       const hasWidth = size.width > 0

--- a/ui/src/components/QCalendarMonth.js
+++ b/ui/src/components/QCalendarMonth.js
@@ -135,7 +135,8 @@ export default defineComponent({
       ariaDateFormatter,
       // methods
       dayStyleDefault,
-      getRelativeClasses
+      getRelativeClasses,
+      selectedDatesPropArray
     } = useCommon(props, { startDate, endDate, times })
 
     const parsedValue = computed(() => {
@@ -660,7 +661,7 @@ export default defineComponent({
         class: {
           'q-calendar-month__day': true,
           ...dayClass,
-          ...getRelativeClasses(day, outside, Array.from(props.selectedDates), props.selectedStartEndDates, props.hover),
+          ...getRelativeClasses(day, outside, selectedDatesPropArray.value, props.selectedStartEndDates, props.hover),
           'q-active-date': activeDate === true,
           disabled: props.enableOutsideDays !== true && outside === true,
           'q-calendar__hoverable': props.hoverable === true,
@@ -800,9 +801,9 @@ export default defineComponent({
       const dayBtnSlot = slots[ 'head-day-button' ]
 
       const selectedDate = (
-        props.selectedDates
-          && Array.from(props.selectedDates).length > 0
-          && Array.from(props.selectedDates).includes(day.date)
+        selectedDatesPropArray.value
+          && selectedDatesPropArray.value.length > 0
+          && selectedDatesPropArray.value.includes(day.date)
       )
 
       const activeDate = props.noActiveDate !== true && __isActiveDate(day)

--- a/ui/src/components/QCalendarMonth.js
+++ b/ui/src/components/QCalendarMonth.js
@@ -660,7 +660,7 @@ export default defineComponent({
         class: {
           'q-calendar-month__day': true,
           ...dayClass,
-          ...getRelativeClasses(day, outside, props.selectedDates, props.selectedStartEndDates, props.hover),
+          ...getRelativeClasses(day, outside, Array.from(props.selectedDates), props.selectedStartEndDates, props.hover),
           'q-active-date': activeDate === true,
           disabled: props.enableOutsideDays !== true && outside === true,
           'q-calendar__hoverable': props.hoverable === true,
@@ -801,8 +801,8 @@ export default defineComponent({
 
       const selectedDate = (
         props.selectedDates
-          && props.selectedDates.length > 0
-          && props.selectedDates.includes(day.date)
+          && Array.from(props.selectedDates).length > 0
+          && Array.from(props.selectedDates).includes(day.date)
       )
 
       const activeDate = props.noActiveDate !== true && __isActiveDate(day)

--- a/ui/src/composables/useCommon.js
+++ b/ui/src/composables/useCommon.js
@@ -225,6 +225,10 @@ export default function (props, {
     return undefined
   }
 
+  const selectedDatesPropArray = computed(() => {
+    return props.selectedDates !== null ? Array.from(props.selectedDates) : null
+  })
+
   return {
     weekdaySkips,
     parsedStart,
@@ -238,6 +242,7 @@ export default function (props, {
     getRelativeClasses,
     startOfWeek,
     endOfWeek,
-    dayStyleDefault
+    dayStyleDefault,
+    selectedDatesPropArray
   }
 }

--- a/ui/src/composables/useCommon.js
+++ b/ui/src/composables/useCommon.js
@@ -93,7 +93,7 @@ export const useCommonProps = {
     // event, timestamp
   },
   selectedDates: {
-    type: Array,
+    type: [ Array, Set ],
     default: () => []
   },
   selectedStartEndDates: {


### PR DESCRIPTION
This PR allows to use Javascript's `Sets` as `selected-dates` to handle uniqueness automatically if wanted.
- https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Set

I placed it into `useCommon` as it seems to be the natural way it do it following your example

Please tell me if this features seems interesting to you and if you know a better way to implement it.
Thank you very much for your work!