### PR TITLE
Cannot use import statement outside a module

### DIFF
--- a/app-extension/src/boot/register.js
+++ b/app-extension/src/boot/register.js
@@ -1,4 +1,6 @@
-import Vue from 'vue'
-import VuePlugin from '@quasar/quasar-ui-qcalendar'
+const { boot } = require("quasar/wrappers");
+const VuePlugin = require("@quasar/quasar-ui-qcalendar");
 
-Vue.use(VuePlugin)
+module.exports = boot(({ app }) => {
+  app.use(VuePlugin);
+});


### PR DESCRIPTION
If you use Quasar + SSR:

import { boot } from 'quasar/wrappers'
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1153:20)
    at Module._compile (node:internal/modules/cjs/loader:1205:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at D:\Projects\front\dist\ssr\server\server-entry.js:1:25248
    at async Promise.all (index 1)