### PR TITLE
fix(ui): use correct type definitions for createNativeLocaleFormatter…

### DIFF
--- a/ui/src/utils/Timestamp.json
+++ b/ui/src/utils/Timestamp.json
@@ -1165,7 +1165,7 @@
           "type": "Function",
           "tsType": "TimestampFormatOptions",
           "required": true,
-          "desc": "A function that passes the timestamp and a boolean",
+          "desc": "A function that passes the timestamp and a boolean, and returns an Intl.DateTimeFormatter",
           "__exemption": [ "examples" ],
           "params": {
             "timestamp": {
@@ -1182,7 +1182,7 @@
           },
           "returns": {
             "type": "Object",
-            "tsType": "TimestampFormatter",
+            "tsType": "Intl.DateTimeFormatOptions",
             "desc": "This uses the Intl.DateTimeFormat function of the browser. Options are specified [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat)",
             "examples": [
               "{ timeZone: 'UTC', month: 'long' }",
@@ -1194,9 +1194,27 @@
         }
       },
       "returns": {
-        "type": "String",
-        "desc": "The output of the operation",
+        "type": "Function",
+        "desc": "A function that takes a timestamp and a boolean and returns a formatted string.",
+        "tsType": "TimestampFormatter",
+        "params": {
+          "timestamp": {
+            "type": "Object",
+            "tsType": "Timestamp",
+            "desc": "A timestamp object",
+            "__exemption": [ "examples" ]
+          },
+          "short": {
+            "type": "Boolean",
+            "desc": "if true, specifies to use the short version (ie: 'Monday' to be returns as 'Mon', 'January' to be returned as 'Jan', etc)",
+            "__exemption": [ "examples" ]
+          }
+        },
+        "returns": {
+          "type": "String",
+          "desc": "A string containing the formatted date/time",
         "__exemption": [ "examples" ]
+        }
       },
     "__exemption": [ "examples" ]
     },
@@ -1511,7 +1529,7 @@
           "weekdayFormatter('Sun', 'long', 'de')",
           "weekdayFormatter('Fri', 'short', 'fr')",
           "weekdayFormatter('Sat', 'narrow', 'fi')"
-        ]  
+        ]
       }
     },
     "getWeekdayNames": {
@@ -1583,7 +1601,7 @@
           "monthFormatter('Sun', 'long', 'de')",
           "monthFormatter('Fri', 'short', 'fr')",
           "monthFormatter('Sat', 'narrow', 'fi')"
-        ]  
+        ]
       }
     },
     "getMonthNames": {

--- a/ui/types/types.d.ts
+++ b/ui/types/types.d.ts
@@ -21,7 +21,7 @@ export type TimestampArray = Timestamp[]
 export type TimestampOrNull = Timestamp | null
 
 export type TimestampFormatter = (timestamp: Timestamp, short: boolean) => string;
-export type TimestampFormatOptions = (timestamp: Timestamp, short: boolean) => TimestampFormatter;
+export type TimestampFormatOptions = (timestamp: Timestamp, short: boolean) => Intl.DateTimeFormatOptions;
 export type TimestampMoveOperation = (timestamp: Timestamp) => Timestamp;
 
 export interface TimeObject {


### PR DESCRIPTION
This addresses typescript compiling errors when using the createNativeLocaleFormatter function per the examples in the documentation.  The return type of this function is a function, not a string.

Tested this fix on my project, which uses the following snippets of code (taken from docs/src/examples/DayCustomHeader.vue):

```
<div style="width: 100%; font-size: 0.9em">
   {{ monthFormatter(day, true) }}
</div>
```

```
const  monthFormatter = monthFormatterFunc(),

function monthFormatterFunc() {
  const longOptions: Intl.DateTimeFormatOptions = {
    timeZone: 'UTC',
    month: 'long',
  };
  const shortOptions: Intl.DateTimeFormatOptions = {
    timeZone: 'UTC',
    month: 'short',
  };

  return createNativeLocaleFormatter(locale.value, (_tms, short) =>
    short ? shortOptions : longOptions
  );
}```
… (#439)