### PR TITLE
fix mouse composable overwriting previous listeners (multi calendar)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@quasar/quasar-ui-qcalendar",
-  "version": "4.0.0-beta.19",
-  "author": "Jeff Galbraith <jeff@quasar.dev>",
+  "name": "@daniel.willms/quasar-ui-qcalendar",
+  "version": "4.0.0-beta.19-fork",
+  "author": "Daniel Willms <daniel.willms@glave.de>",
   "description": "QCalendar - Day/Month/Week Calendars, Popups, Date Pickers, Schedules, Agendas, Planners and Tasks for your Vue Apps",
   "license": "MIT",
   "module": "dist/index.esm.js",
@@ -26,16 +26,12 @@
     "build:api": "node build/build.api.js",
     "test": "jest --runInBand --no-cache"
   },
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/hawkeye64"
-  },
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/quasarframework/quasar-ui-qcalendar.git"
+    "url": "git+https://github.com/danielwillms/quasar-ui-qcalendar.git"
   },
   "bugs": "https://github.com/quasarframework/quasar-ui-qcalendar/issues",
   "homepage": "https://github.com/quasarframework/quasar-ui-qcalendar",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@daniel.willms/quasar-ui-qcalendar",
-  "version": "4.0.0-beta.19-fork",
-  "author": "Daniel Willms <daniel.willms@glave.de>",
+  "name": "@quasar/quasar-ui-qcalendar",
+  "version": "4.0.0-beta.19",
+  "author": "Jeff Galbraith <jeff@quasar.dev>",
   "description": "QCalendar - Day/Month/Week Calendars, Popups, Date Pickers, Schedules, Agendas, Planners and Tasks for your Vue Apps",
   "license": "MIT",
   "module": "dist/index.esm.js",
@@ -26,12 +26,16 @@
     "build:api": "node build/build.api.js",
     "test": "jest --runInBand --no-cache"
   },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/hawkeye64"
+  },
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/danielwillms/quasar-ui-qcalendar.git"
+    "url": "git+https://github.com/quasarframework/quasar-ui-qcalendar.git"
   },
   "bugs": "https://github.com/quasarframework/quasar-ui-qcalendar/issues",
   "homepage": "https://github.com/quasarframework/quasar-ui-qcalendar",


### PR DESCRIPTION
When having multiple calendars rendered on one page, events would behave incorrectly. 
Due to having global variables store the listeners/emit in `useMouse.js`, they were dropped, when a new calendar would initialize them.
E.g. Having 2 calendars, both listening to `onTimeClick`-Event, now clicking on calendar1 would cause calendar2's listener to fire. 
I stored the emit/listeners in the default function, which seems to solve the problem. Not sure if there were other reasons for having these global?