### PR TITLE
fix(447): style disabled class and attribute only in the .q-calendar wrapper

### DIFF
--- a/ui/src/css/q-calendar.sass
+++ b/ui/src/css/q-calendar.sass
@@ -158,13 +158,13 @@
     > .q-calendar__focus-helper
       opacity: .22
 
-.disabled, [disabled]
-  &, * // @stylint ignore
-    outline: 0 !important
-    cursor: not-allowed !important
-
-.disabled, [disabled]
-  opacity: .6 !important
+  .disabled, [disabled]
+    &, * // @stylint ignore
+      outline: 0 !important
+      cursor: not-allowed !important
+  
+  .disabled, [disabled]
+    opacity: .6 !important
 
 
 .q-calendar


### PR DESCRIPTION
Fixes: #447 

Only styles the disabled class and attribute when in the .q-calendar wrapper preventing styling issues when used in other frameworks/projects that has `disabled` styling.