### PR TITLE
fix: scss leading to invalid css

### DIFF
--- a/packages/ui/src/css/calendar-month-mini.scss
+++ b/packages/ui/src/css/calendar-month-mini.scss
@@ -198,12 +198,11 @@
               &:before {
                 width: 50%;
                 right: auto;
-
-                // when first and last are same day
-                &.q-range-first {
-                  &:before {
-                    width: 0;
-                  }
+              }
+              // when first and last are same day
+              &.q-range-first {
+                &:before {
+                  width: 0;
                 }
               }
             }


### PR DESCRIPTION
discussion related to this https://github.com/sass/dart-sass/issues/1677

but I was trying to use rolldown which uses lightning-css as a minifier and it was trying to minify the css from this repo and it was complaining about invalid css.

Basically a psuedo selector like before apparently cant have any children selectors as it was outputting
Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Delim('.')

